### PR TITLE
Bump SciMLBase compat to v3 and bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GlobalDiffEq"
 uuid = "1d72d19b-84cc-4cb7-a099-7cbdb9ccc67c"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -17,7 +17,7 @@ OrdinaryDiffEq = "5.42, 6.103"
 PrecompileTools = "1"
 Reexport = "0.2, 1.0"
 Richardson = "1.2"
-SciMLBase = "2"
+SciMLBase = "2, 3"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
## Summary
- Update SciMLBase compat bounds to include v3
- Bump package version (minor): 1.0.0 → 1.1.0
- No code changes needed - package doesn't use deprecated SciMLBase v2 patterns
- Supersedes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)