### PR TITLE
Migrate to OrdinaryDiffEq v7 / SciMLBase v3 / DiffEqBase v7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GlobalDiffEq"
 uuid = "1d72d19b-84cc-4cb7-a099-7cbdb9ccc67c"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -12,18 +12,20 @@ Richardson = "708f8203-808e-40c0-ba2d-98a6953ed40d"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [compat]
-DiffEqBase = "6.47"
-OrdinaryDiffEq = "5.42, 6.103"
+DiffEqBase = "6.47, 7"
+OrdinaryDiffEq = "5.42, 6.103, 7"
 PrecompileTools = "1"
 Reexport = "0.2, 1.0"
 Richardson = "1.2"
-SciMLBase = "2, 3.0"
-julia = "1.6"
+SciMLBase = "2, 3"
+julia = "1.10"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+OrdinaryDiffEqSSPRK = "669c94d9-1f4b-4b64-b377-1aa079aa2388"
+OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["LinearAlgebra", "Pkg", "Test"]
+test = ["LinearAlgebra", "OrdinaryDiffEqSSPRK", "OrdinaryDiffEqTsit5", "Pkg", "Test"]

--- a/src/GlobalDiffEq.jl
+++ b/src/GlobalDiffEq.jl
@@ -54,9 +54,10 @@ export GlobalRichardson
     prob = ODEProblem(f!, u0, tspan)
 
     @compile_workload begin
-        # Precompile with SSPRK33 (commonly used explicit method)
+        # Precompile with Tsit5 (exported from the default OrdinaryDiffEq set
+        # on v7; available on all supported OrdinaryDiffEq versions).
         solve(
-            prob, GlobalRichardson(OrdinaryDiffEq.SSPRK33()),
+            prob, GlobalRichardson(OrdinaryDiffEq.Tsit5()),
             dt = 0.1, reltol = 1.0e-3, abstol = 1.0e-6
         )
     end

--- a/src/GlobalDiffEq.jl
+++ b/src/GlobalDiffEq.jl
@@ -54,8 +54,6 @@ export GlobalRichardson
     prob = ODEProblem(f!, u0, tspan)
 
     @compile_workload begin
-        # Precompile with Tsit5 (exported from the default OrdinaryDiffEq set
-        # on v7; available on all supported OrdinaryDiffEq versions).
         solve(
             prob, GlobalRichardson(OrdinaryDiffEq.Tsit5()),
             dt = 0.1, reltol = 1.0e-3, abstol = 1.0e-6

--- a/test/jet/Project.toml
+++ b/test/jet/Project.toml
@@ -2,9 +2,10 @@
 GlobalDiffEq = "1d72d19b-84cc-4cb7-a099-7cbdb9ccc67c"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+OrdinaryDiffEqSSPRK = "669c94d9-1f4b-4b64-b377-1aa079aa2388"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 GlobalDiffEq = "1"
 JET = "0.9, 0.10, 0.11"
-OrdinaryDiffEq = "5.42, 6.103"
+OrdinaryDiffEq = "5.42, 6.103, 7"

--- a/test/jet/jet_tests.jl
+++ b/test/jet/jet_tests.jl
@@ -1,5 +1,4 @@
 using GlobalDiffEq, OrdinaryDiffEq
-# SSPRK33 moved out of the default OrdinaryDiffEq export set on v7.
 using OrdinaryDiffEqSSPRK
 using JET
 using Test

--- a/test/jet/jet_tests.jl
+++ b/test/jet/jet_tests.jl
@@ -1,4 +1,6 @@
 using GlobalDiffEq, OrdinaryDiffEq
+# SSPRK33 moved out of the default OrdinaryDiffEq export set on v7.
+using OrdinaryDiffEqSSPRK
 using JET
 using Test
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,5 @@
 using Pkg
 using GlobalDiffEq, OrdinaryDiffEq, LinearAlgebra
-# SSPRK33 moved out of the default OrdinaryDiffEq export set on v7; load the
-# sublibrary explicitly so the tests continue to exercise a non-default solver.
 using OrdinaryDiffEqSSPRK
 using Test
 import DiffEqBase: SciMLBase

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,8 @@
 using Pkg
 using GlobalDiffEq, OrdinaryDiffEq, LinearAlgebra
+# SSPRK33 moved out of the default OrdinaryDiffEq export set on v7; load the
+# sublibrary explicitly so the tests continue to exercise a non-default solver.
+using OrdinaryDiffEqSSPRK
 using Test
 import DiffEqBase: SciMLBase
 


### PR DESCRIPTION
## Summary

Migrates GlobalDiffEq to the new OrdinaryDiffEq v7 / SciMLBase v3 / DiffEqBase v7 / RecursiveArrayTools v4 ecosystem. Supersedes and subsumes the Dependabot PR #43 (which only widened the `DiffEqBase` compat entry).

GlobalDiffEq is a thin wrapper over OrdinaryDiffEq that implements Richardson extrapolation on the solver's output-time grid. The wrapper touches very little of the v7 breakage surface. I audited every category listed in `BREAKING_CHANGES_v7.md` against both `src/` and `test/`; the only code-level hit is the loss of the blanket `@reexport` from `OrdinaryDiffEq` in v7 (SSPRK33 is no longer in scope via `using OrdinaryDiffEq`).

## Breaking-change audit (grep over `src/` and `test/`)

**SciMLBase v3 renames** — no hits:
- `u_modified!`, `DEAlgorithm`/`DEProblem`/`DESolution` (bare), `sol.destats`, `has_destats`, `symbol_to_ReturnCode`, `syms`/`paramsyms`/`indepsym`, `sol.x`/`sol.lb`/`sol.ub`/`sol.minimizer`/`sol.minimum`, `tuples()`/`intervals()`/`IntegratorTuples`/`IntegratorIntervals`/`TimeChoiceIterator`, `QuadratureProblem`

**DiffEqBase v7 removals** — no hits:
- `has_destats`, `RECOMPILE_BY_DEFAULT`, `fastpow`, `concrete_solve`, `DEStats`

**RecursiveArrayTools v4 semantics change** — no hits:
- `sol[i]`, `length(sol)`, `eachindex(sol)`, `iterate(sol)`, `first(sol)`/`last(sol)`, `map(f, sol)`, `maximum(sol)`
- The package only touches `sol.u[end]` and calls the interpolator via `sol.(tstops)`, both of which are unaffected by the `AbstractVectorOfArray <: AbstractArray` change.

**Bool kwargs banned in v7** — no hits:
- `verbose=`, `alias=`, `alias_u0`/`alias_du0`, `autodiff=true/false`, `lazy=true/false`

**Algorithm struct changes** — no hits:
- `chunk_size`/`diff_type`/`standardtag`/`precs` kwargs, type-parameter usage on algorithm structs

**Controller refactor** — no hits:
- `gamma`/`beta1`/`beta2`/`qmin`/`qmax`/`qsteady_min`/`qsteady_max`/`qoldinit`, `integrator.EEst`/`qold`/`q11`/`erracc`/`dtacc`

**Ensemble signature change** — no hits:
- `prob_func`/`output_func`

**Tableau renames** — no hits:
- No `construct*` tableau function used.

**Package scope reduction** — 4 hits, all fixed:
- `test/runtests.jl`: `SSPRK33()` used three times with only `using OrdinaryDiffEq`. Added `using OrdinaryDiffEqSSPRK` and added `OrdinaryDiffEqSSPRK` to `[extras]`/`[targets]`.
- `test/jet/jet_tests.jl`: same two `SSPRK33()` references. Added `using OrdinaryDiffEqSSPRK` and added the dep to `test/jet/Project.toml`.
- `src/GlobalDiffEq.jl`: `@compile_workload` used `OrdinaryDiffEq.SSPRK33()`. SSPRK33 is no longer reachable through the `OrdinaryDiffEq` module on v7 (the v7 main module only imports the default set). Switched the workload to `OrdinaryDiffEq.Tsit5()`, which is in the default set on v7 and is available on all supported versions — no new dep needed for the package itself.

## Changes

- `Project.toml`: `DiffEqBase = "6.47, 7"`, `OrdinaryDiffEq = "5.42, 6.103, 7"`, `SciMLBase = "2, 3"`, `julia = "1.10"` (v7 ecosystem requirement). Version bumped to `1.1.0`. `OrdinaryDiffEqSSPRK` and `OrdinaryDiffEqTsit5` added to `[extras]`/`[targets]` (the latter for robustness in case the default `using OrdinaryDiffEq` export set shrinks further).
- `src/GlobalDiffEq.jl`: precompile workload switched from `OrdinaryDiffEq.SSPRK33()` to `OrdinaryDiffEq.Tsit5()`.
- `test/runtests.jl`: `using OrdinaryDiffEqSSPRK` added.
- `test/jet/Project.toml`: `OrdinaryDiffEqSSPRK` added to deps; `OrdinaryDiffEq` compat widened to include `7`.
- `test/jet/jet_tests.jl`: `using OrdinaryDiffEqSSPRK` added.

No `test/Project.toml` created — test deps continue to live in the main `Project.toml`'s `[extras]`/`[targets]` per SciML convention.

## Test plan

- [x] `Pkg.test("GlobalDiffEq")` on Julia 1.12.6 against the v7 dev stack (OrdinaryDiffEq master + all sublibraries dev'd, DiffEqBase v7.0.0, SciMLBase v3.x) — **6/6 tests pass**.
- [x] `Pkg.test("GlobalDiffEq")` on Julia 1.12.6 against the stable v6 stack (OrdinaryDiffEq v6.x, DiffEqBase v6.x, SciMLBase v2.x) — **6/6 tests pass**. Confirms the bump is strictly compat-widening for downstream users still on v6.
- [ ] JET test group not exercised locally (requires separate jet environment activation and was not part of the v7 migration per se); CI on this PR will cover it. The only change there is adding `using OrdinaryDiffEqSSPRK` plus a dep — no semantic change.

## Relation to #43

Dependabot PR #43 only widens `DiffEqBase` compat in `Project.toml`. That alone is insufficient: `using OrdinaryDiffEq` followed by a bare `SSPRK33()` in the test suite and in the precompile workload would fail to resolve on v7 because SSPRK33 is no longer reachable via the `OrdinaryDiffEq` module. This PR carries the DiffEqBase compat bump and adds the full set of code-level fixes plus the OrdinaryDiffEq and SciMLBase compat bumps. Recommend closing #43 in favor of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)