### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
-      - "/test"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,0 +1,22 @@
+name: Downgrade
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}
+
+jobs:
+  downgrade:
+    name: "Downgrade"
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "lts"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## What changed

Convert the remaining inline CI checks to the centralized `SciML/.github` reusable workflows (`@v1`), so every job is a central caller with `secrets: "inherit"`.

### Converted (inline -> central)
- **Runic** (`FormatCheck.yml`): `fredrikekre/runic-action` inline -> `runic.yml@v1`. Kept `name: format-check` and the existing `on:` triggers.
- **SpellCheck** (`SpellCheck.yml`): `crate-ci/typos@v1.18.0` inline -> `spellcheck.yml@v1`. Kept `name`/`on:`.

### Added (new caller)
- **Downgrade** (`Downgrade.yml`): new `downgrade.yml@v1` caller (`julia-version: lts`, `skip: Pkg,TOML`). The package had no downgrade check before.

### Unchanged
- **Tests** (`Tests.yml`): already a `tests.yml@v1` caller (tests + JET jobs, matrices `1`/`lts`/`pre` and `1`/`lts`, group `JET`), already `secrets: "inherit"`. Left exactly as-is.
- **TagBot.yml**: untouched.
- No `docs/make.jl`, so no Documentation caller. No existing Downstream/Benchmark/CompatHelper workflows to convert or delete.

### dependabot.yml
- Removed the `crate-ci/typos` version ignore.
- Restricted the `julia` ecosystem to `directory: /` (the only dir with a `Project.toml`; test deps live in the root `Project.toml` `[extras]`/`[targets]`, so `/test` had no manifest). `github-actions` weekly, `julia` daily, group `all-julia-packages: ["*"]` preserved.

## Local verification
- Runic: ran `Runic.main(["--inplace","."])` -> no changes (already clean; was running inline).
- Typos: ran `typos -w .` -> 0 fixes, `typos .` exits 0 (clean). Existing `.typos.toml` allowlist preserved.
- All changed YAML validated with `yaml.safe_load`.

**typos fixed:** 0
**Runic formatting applied:** no (already clean)

## Note on branch protection
Check names change (jobs now run under the reusable workflow's job names, e.g. "Runic Format Check", "Spell Check with Typos", "Downgrade Tests"). Any required-status-check rules in branch protection will need updating to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)