### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -14,29 +14,5 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-          - "lts"
-          - "pre"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "${{ matrix.version }}"
-    secrets: "inherit"
-
-  jet:
-    name: "JET"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-          - "lts"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "${{ matrix.version }}"
-      group: "JET"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,5 @@
+[Core]
+versions = ["lts", "1", "pre"]
+
+[JET]
+versions = ["lts", "1"]


### PR DESCRIPTION
This converts the root test workflow (`.github/workflows/Tests.yml`) to the canonical `grouped-tests.yml@v1` thin caller, moving the `(group, version)` matrix out of hand-maintained YAML and into a root `test/test_groups.toml`.

## What changed

- **`.github/workflows/Tests.yml`** — the two matrix jobs (`tests` + `jet`, each calling `tests.yml@v1`) are replaced by a single thin caller:
  ```yaml
  jobs:
    tests:
      uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
      secrets: "inherit"
  ```
  Filename and `name: "Tests"` are preserved so existing branch-protection status checks remain valid. `on:` triggers and `concurrency:` are kept verbatim.
- **`test/test_groups.toml`** (new, repo root) — declares the matrix:
  ```toml
  [Core]
  versions = ["lts", "1", "pre"]

  [JET]
  versions = ["lts", "1"]
  ```

No `with:` overrides are needed: `runtests.jl` already dispatches on the default `GROUP` env var, and `check-bounds` (`yes`), `coverage` (`true`), and `coverage-directories` (`src,ext`) all match the centralized workflow defaults that the old jobs were already using.

## Matrix match — 5/5 exact

Old `Tests.yml`:
- `tests` job (GROUP unset → "All"/Core block) on `[1, lts, pre]` → 3 cells
- `jet` job (GROUP=JET) on `[1, lts]` → 2 cells

New, via `compute_affected_sublibraries.jl <root> --root-matrix`:
```
Core: lts, 1, pre
JET:  lts, 1
```
= the same 5 `(group, version)` cells. Verified by running the v1 matrix script locally against this branch. TOML and YAML both parse cleanly.

## QA

Category A: this repo already has `Core`/`JET` GROUP dispatch in `test/runtests.jl` (JET is the QA-equivalent here, on `[lts, 1]`), so no `runtests.jl` change and no new QA run were required — static matrix-verify only. No source bugs surfaced; no exclusions added. Project.toml `[compat]` is already complete with a `julia = "1.10"` LTS floor, so no metadata changes were needed.

Ignore until reviewed by @ChrisRackauckas.