### PR TITLE
Fix incorrect SafeTestsets UUID in [extras] (breaks all CI resolve)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ julia = "1.10"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrdinaryDiffEqSSPRK = "669c94d9-1f4b-4b64-b377-1aa079aa2388"
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
-SafeTestsets = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/test/JET/Project.toml
+++ b/test/JET/Project.toml
@@ -3,7 +3,7 @@ GlobalDiffEq = "1d72d19b-84cc-4cb7-a099-7cbdb9ccc67c"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 OrdinaryDiffEqSSPRK = "669c94d9-1f4b-4b64-b377-1aa079aa2388"
-SafeTestsets = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 


### PR DESCRIPTION
## Problem

Master CI is red on every test job — `Core` (Julia lts/1/pre), `JET` (Julia lts/1), and `Downgrade`. All fail identically, before any test runs, with:

```
Unsatisfiable requirements detected for package StaticArraysCore [1e83bf80]:
 StaticArraysCore [1e83bf80] log:
 ├─possible versions are: 1.0.0 - 1.4.4 or uninstalled
 └─restricted to versions [0.0.1, 0.1] by project — no versions left
```

## Root cause

The SciMLTesting v1.2 migration (#50) added `SafeTestsets` to `[extras]` but used **StaticArraysCore's** UUID (`1e83bf80-4336-4d27-bf5d-d5a4f845583c`) instead of SafeTestsets' real UUID (`1bc83da4-3b8d-516f-aca4-4fe02f6d838f`).

As a result, the test-only compat entry `SafeTestsets = "0.0.1, 0.1"` was applied to the package with UUID `1e83bf80` — which is actually StaticArraysCore. StaticArraysCore only has registered versions in the `1.x` range, so the `[0.0.1, 0.1]` constraint left no satisfiable version and Pkg failed to resolve the test target.

## Fix

Correct the `SafeTestsets` UUID in `[extras]` to its registered value.

```diff
-SafeTestsets = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
```

## Local verification (Julia 1.12, matching the failing CI runner)

`julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` now resolves and passes:

```
Status `.../jl_21HmkB/Project.toml`
  [1bc83da4] SafeTestsets v0.1.0        # correct UUID, satisfies compat 0.0.1, 0.1
  [1e83bf80] StaticArraysCore v1.4.4    # resolves independently at its real version
...
Test Summary:       | Pass  Total   Time
Basic functionality |    1      1  11.3s
Algorithm traits forwarding |    3      3
BigFloat support    |    2      2
     Testing GlobalDiffEq tests passed
```

Before this change, `Pkg.test()` errors out at the resolve step with the `StaticArraysCore` unsatisfiable-requirements error shown above.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
