### PR TITLE
Add adjoint-based global error control

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,15 +1,20 @@
 name = "GlobalDiffEq"
 uuid = "1d72d19b-84cc-4cb7-a099-7cbdb9ccc67c"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Richardson = "708f8203-808e-40c0-ba2d-98a6953ed40d"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
+SciMLSensitivity = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
+SciMLStructures = "53ae85a6-f571-4167-b2af-e1d143709226"
 
 [compat]
 DiffEqBase = "7"
@@ -18,16 +23,19 @@ OrdinaryDiffEq = "7"
 OrdinaryDiffEqSSPRK = "2"
 OrdinaryDiffEqTsit5 = "2"
 PrecompileTools = "1.1"
+QuadGK = "2.11"
+Random = "1"
 Reexport = "0.2, 1.0"
 Richardson = "1.2"
 SafeTestsets = "0.0.1, 0.1"
 SciMLBase = "3"
+SciMLSensitivity = "7.116"
+SciMLStructures = "1.10"
 SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"
 
 [extras]
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrdinaryDiffEqSSPRK = "669c94d9-1f4b-4b64-b377-1aa079aa2388"
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
@@ -35,4 +43,4 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["LinearAlgebra", "OrdinaryDiffEqSSPRK", "OrdinaryDiffEqTsit5", "SafeTestsets", "SciMLTesting", "Test"]
+test = ["OrdinaryDiffEqSSPRK", "OrdinaryDiffEqTsit5", "SafeTestsets", "SciMLTesting", "Test"]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,5 +1,25 @@
 # GlobalDiffEq.jl
 
+GlobalDiffEq provides ODE solver wrappers that estimate or control error over
+the full integration interval.
+
+## Algorithms
+
 ```@autodocs
 Modules = [GlobalDiffEq]
 ```
+
+`GlobalAdjoint` implements adjoint-based a posteriori error estimation. It uses
+SciMLSensitivity's public adjoint problem and vector-Jacobian-product machinery,
+then integrates the numerical solution's defect against randomized terminal
+directions. For example:
+
+```julia
+alg = GlobalAdjoint(Tsit5(); gtol = 1.0e-6)
+sol = solve(prob, alg)
+```
+
+The method follows Yang Cao and Linda Petzold, [*A Posteriori Error Estimation
+and Global Error Control for Ordinary Differential Equations by the Adjoint
+Method*](https://doi.org/10.1137/S1064827503420969), SIAM Journal on Scientific
+Computing 26(2), 2004.

--- a/src/GlobalDiffEq.jl
+++ b/src/GlobalDiffEq.jl
@@ -3,7 +3,8 @@ module GlobalDiffEq
 using Reexport: @reexport
 @reexport using DiffEqBase
 
-import OrdinaryDiffEq, Richardson, SciMLBase
+import LinearAlgebra, OrdinaryDiffEq, QuadGK, Random, Richardson, SciMLBase,
+    SciMLSensitivity, SciMLStructures
 using PrecompileTools: @setup_workload, @compile_workload
 
 abstract type GlobalDiffEqAlgorithm <: SciMLBase.AbstractODEAlgorithm end
@@ -47,7 +48,9 @@ function SciMLBase.__solve(
     return sol
 end
 
-export GlobalRichardson
+include("adjoint.jl")
+
+export GlobalAdjoint, GlobalRichardson, adjoint_error_estimate
 
 @setup_workload begin
     # Simple test ODE: exponential decay du/dt = -u

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -1,0 +1,397 @@
+"""
+    GlobalAdjoint(alg; gtol=nothing, adjoint_alg=alg, sensealg, samples=2,
+                  rng=Random.default_rng(), maxiters=6, safety=0.8)
+
+Wrap an ODE algorithm with adjoint-based global error estimation and control.
+Set the requested absolute endpoint error with the `gtol` constructor keyword:
+
+```julia
+solve(prob, GlobalAdjoint(Tsit5(); gtol = 1.0e-6))
+```
+
+The algorithm solves the ODE with local tolerances, estimates the 2-norm of the
+endpoint error using `samples` orthogonal random projections, and tightens the
+local tolerances until the estimate is at most `gtol`. The estimate is
+probabilistic for systems with more than one state; the default of two samples
+is accurate within a factor of ten with probability greater than 99% under the
+small-sample estimate in Cao and Petzold (2004).
+
+Omit `gtol` when using the algorithm only with [`adjoint_error_estimate`](@ref).
+`maxiters` limits the number of forward-solve refinements, while `safety`
+controls each local-tolerance reduction. The `adjoint_abstol`,
+`adjoint_reltol`, `quadrature_abstol`, and `quadrature_reltol` constructor
+keywords control the numerical adjoints and defect quadrature.
+
+`sensealg` must be a `SciMLSensitivity.QuadratureAdjoint`. Its default uses
+SciMLSensitivity's ForwardDiff-based state Jacobian construction. Parameters
+are presented to SciMLSensitivity as fixed data because this estimator does not
+differentiate with respect to them. `adjoint_alg` selects the solver for the
+reverse-time adjoint problems.
+
+This implementation supports forward-time, standard-mass-matrix ODEs with
+real vector states and no callbacks. The wrapped solver must provide a dense
+first-derivative interpolation.
+"""
+struct GlobalAdjoint{A, AA, S, R, G, V} <: GlobalDiffEqAlgorithm
+    alg::A
+    adjoint_alg::AA
+    sensealg::S
+    samples::Int
+    rng::R
+    gtol::G
+    options::V
+end
+
+function GlobalAdjoint(
+        alg;
+        adjoint_alg = alg,
+        sensealg = SciMLSensitivity.QuadratureAdjoint(
+            autojacvec = true
+        ),
+        samples = 2,
+        rng = Random.default_rng(),
+        gtol = nothing,
+        maxiters = 6,
+        safety = 0.8,
+        adjoint_abstol = gtol === nothing ? 1.0e-10 : min(gtol / 100, 1.0e-10),
+        adjoint_reltol = gtol === nothing ? 1.0e-8 : min(gtol / 100, 1.0e-8),
+        quadrature_abstol = gtol === nothing ? 0.0 : zero(gtol),
+        quadrature_reltol = 1.0e-6
+    )
+    samples isa Integer || throw(ArgumentError("samples must be an integer"))
+    samples > 0 || throw(ArgumentError("samples must be positive"))
+    sensealg isa SciMLSensitivity.QuadratureAdjoint ||
+        throw(ArgumentError("sensealg must be a SciMLSensitivity.QuadratureAdjoint"))
+    (gtol === nothing || _positive_finite_real(gtol)) ||
+        throw(ArgumentError("gtol must be a positive finite real number"))
+    maxiters isa Integer && maxiters > 0 ||
+        throw(ArgumentError("maxiters must be a positive integer"))
+    safety isa Real && isfinite(safety) && 0 < safety < 1 ||
+        throw(ArgumentError("safety must be between zero and one"))
+    _validate_tolerances(adjoint_abstol, adjoint_reltol, "adjoint")
+    _validate_tolerances(quadrature_abstol, quadrature_reltol, "quadrature")
+    options = (;
+        maxiters = Int(maxiters), safety,
+        adjoint_abstol, adjoint_reltol,
+        quadrature_abstol, quadrature_reltol,
+    )
+    return GlobalAdjoint(alg, adjoint_alg, sensealg, Int(samples), rng, gtol, options)
+end
+
+_positive_finite_real(value) = value isa Real && isfinite(value) && value > 0
+
+function _validate_tolerances(abstol, reltol, name)
+    abstol isa Real && isfinite(abstol) && abstol >= 0 ||
+        throw(ArgumentError("$(name)_abstol must be a nonnegative finite real number"))
+    reltol isa Real && isfinite(reltol) && reltol >= 0 ||
+        throw(ArgumentError("$(name)_reltol must be a nonnegative finite real number"))
+    iszero(abstol) && iszero(reltol) &&
+        throw(ArgumentError("$(name)_abstol and $(name)_reltol cannot both be zero"))
+    return nothing
+end
+
+SciMLBase.allows_arbitrary_number_types(::GlobalAdjoint) = false
+SciMLBase.allowscomplex(::GlobalAdjoint) = false
+SciMLBase.isautodifferentiable(::GlobalAdjoint) = false
+
+struct _FixedParameter{P, T}
+    value::P
+    tunables::Vector{T}
+end
+
+SciMLStructures.isscimlstructure(::_FixedParameter) = true
+SciMLStructures.ismutablescimlstructure(::_FixedParameter) = false
+SciMLStructures.hasportion(::SciMLStructures.AbstractPortion, ::_FixedParameter) = false
+SciMLStructures.hasportion(::SciMLStructures.Tunable, ::_FixedParameter) = true
+
+function SciMLStructures.canonicalize(::SciMLStructures.Tunable, p::_FixedParameter)
+    repack = _ -> p
+    return p.tunables, repack, true
+end
+
+function SciMLStructures.canonicalize(
+        ::SciMLStructures.AbstractPortion, ::_FixedParameter
+    )
+    return nothing, nothing, nothing
+end
+
+function SciMLStructures.replace(
+        ::SciMLStructures.Tunable, p::_FixedParameter, tunables
+    )
+    isempty(tunables) || throw(DimensionMismatch("fixed parameters have no tunable values"))
+    return p
+end
+
+function _fixed_parameter_problem(prob)
+    _validate_adjoint_problem(prob)
+    fixed_parameter = _FixedParameter(prob.p, eltype(prob.u0)[])
+    original_f = SciMLBase.unwrapped_f(prob.f)
+    wrapped_f = if SciMLBase.isinplace(prob)
+        let f = original_f
+            (du, u, p, t) -> f(du, u, p.value, t)
+        end
+    else
+        let f = original_f
+            (u, p, t) -> f(u, p.value, t)
+        end
+    end
+    full_specialized_f = SciMLBase.ODEFunction{
+        SciMLBase.isinplace(prob), SciMLBase.FullSpecialize,
+    }(wrapped_f)
+    return SciMLBase.remake(prob; f = full_specialized_f, p = fixed_parameter)
+end
+
+function _validate_adjoint_problem(prob)
+    prob.u0 isa AbstractVector{<:AbstractFloat} ||
+        throw(ArgumentError("GlobalAdjoint requires a real floating-point vector state"))
+    isempty(prob.u0) && throw(ArgumentError("GlobalAdjoint requires a nonempty state"))
+    prob.tspan[1] < prob.tspan[2] ||
+        throw(ArgumentError("GlobalAdjoint requires a forward-time ODEProblem"))
+    prob.f.mass_matrix == LinearAlgebra.I ||
+        throw(ArgumentError("GlobalAdjoint currently requires the standard mass matrix"))
+    problem_kwargs = values(prob.kwargs)
+    if haskey(problem_kwargs, :callback) && problem_kwargs.callback !== nothing
+        throw(ArgumentError("GlobalAdjoint does not currently support callbacks"))
+    end
+    return nothing
+end
+
+function _validate_adjoint_solution(sol)
+    SciMLBase.successful_retcode(sol) ||
+        throw(ErrorException("the forward solve failed with retcode $(sol.retcode)"))
+    _validate_adjoint_problem(sol.prob)
+    length(sol.t) >= 2 ||
+        throw(ArgumentError("the forward solution must save at least its two endpoints"))
+    return nothing
+end
+
+function _orthogonal_directions(u0, requested_samples, rng)
+    sample_count = min(requested_samples, length(u0))
+    T = eltype(u0)
+    directions = Vector{Vector{T}}()
+    sizehint!(directions, sample_count)
+
+    for _ in 1:sample_count
+        accepted = false
+        for _ in 1:10
+            direction = T[Base.randn(rng) for _ in eachindex(u0)]
+            for _ in 1:2, previous in directions
+                direction .-= LinearAlgebra.dot(previous, direction) .* previous
+            end
+            direction_norm = LinearAlgebra.norm(direction)
+            if direction_norm > sqrt(eps(T))
+                push!(directions, direction ./ direction_norm)
+                accepted = true
+                break
+            end
+        end
+        accepted || error("failed to generate orthogonal random directions")
+    end
+
+    return directions
+end
+
+function _sphere_projection_expectation(dimension, ::Type{T}) where {T}
+    dimension > 0 || throw(ArgumentError("dimension must be positive"))
+    if dimension == 1
+        return one(T)
+    end
+
+    expectation = isodd(dimension) ? one(T) : T(2) / T(pi)
+    first_numerator = isodd(dimension) ? 1 : 2
+    for numerator in first_numerator:2:(dimension - 2)
+        expectation *= T(numerator) / T(numerator + 1)
+    end
+    return expectation
+end
+
+function _adjoint_solution(sol, alg, direction; abstol, reltol)
+    terminal_gradient! = let direction = direction
+        function (out, u, p, t, i)
+            copyto!(out, direction)
+            return nothing
+        end
+    end
+    terminal_time = sol.prob.tspan[2]
+    adjoint_prob = SciMLSensitivity.ODEAdjointProblem(
+        sol, alg.sensealg, alg.adjoint_alg, [terminal_time], terminal_gradient!
+    )
+    adjoint_sol = SciMLBase.solve(
+        adjoint_prob, alg.adjoint_alg;
+        abstol, reltol, dense = true, save_everystep = true
+    )
+    SciMLBase.successful_retcode(adjoint_sol) ||
+        throw(ErrorException("the adjoint solve failed with retcode $(adjoint_sol.retcode)"))
+    return adjoint_sol
+end
+
+function _defect_projection(sol, adjoint_sol; abstol, reltol)
+    prob = sol.prob
+    isinplace = SciMLBase.isinplace(prob)
+
+    function integrand(t)
+        u = sol(t, continuity = :right)
+        du = sol(t, Val{1}, continuity = :right)
+        rhs = if isinplace
+            value = similar(u)
+            prob.f(value, u, prob.p, t)
+            value
+        else
+            prob.f(u, prob.p, t)
+        end
+        lambda = adjoint_sol(t, continuity = :right)
+        return LinearAlgebra.dot(lambda, du - rhs)
+    end
+
+    projection = zero(eltype(prob.u0))
+    for i in 1:(length(sol.t) - 1)
+        left = sol.t[i]
+        right = sol.t[i + 1]
+        left == right && continue
+        interval_projection, _ = QuadGK.quadgk(
+            integrand, left, right; atol = abstol, rtol = reltol
+        )
+        projection += interval_projection
+    end
+    return projection
+end
+
+function _adjoint_error_estimate(
+        sol, alg, directions;
+        adjoint_abstol, adjoint_reltol, quadrature_abstol, quadrature_reltol
+    )
+    projections = map(directions) do direction
+        adjoint_sol = _adjoint_solution(
+            sol, alg, direction; abstol = adjoint_abstol, reltol = adjoint_reltol
+        )
+        _defect_projection(
+            sol, adjoint_sol;
+            abstol = quadrature_abstol, reltol = quadrature_reltol
+        )
+    end
+    T = eltype(sol.prob.u0)
+    sample_count = length(directions)
+    factor = _sphere_projection_expectation(sample_count, T) /
+        _sphere_projection_expectation(length(sol.prob.u0), T)
+    return factor * LinearAlgebra.norm(projections)
+end
+
+"""
+    adjoint_error_estimate(prob, alg::GlobalAdjoint; abstol=1e-6, reltol=1e-3, kwargs...)
+
+Solve an ODE problem and estimate the 2-norm of its global error at the final
+time. The estimate evaluates the dense interpolation defect and projects it
+through reverse-time adjoints constructed by SciMLSensitivity.
+
+`abstol` and `reltol` control the forward solve. Keyword arguments
+`adjoint_abstol`, `adjoint_reltol`, `quadrature_abstol`, and `quadrature_reltol`
+control the numerical adjoint solves and defect quadrature. The random
+directions come from `alg.rng`; their number is `alg.samples`, capped at the
+state dimension.
+"""
+function adjoint_error_estimate(
+        prob::SciMLBase.AbstractODEProblem, alg::GlobalAdjoint, args...;
+        abstol = 1.0e-6,
+        reltol = 1.0e-3,
+        adjoint_abstol = alg.options.adjoint_abstol,
+        adjoint_reltol = alg.options.adjoint_reltol,
+        quadrature_abstol = alg.options.quadrature_abstol,
+        quadrature_reltol = alg.options.quadrature_reltol,
+        kwargs...
+    )
+    haskey(kwargs, :callback) &&
+        throw(ArgumentError("adjoint_error_estimate does not currently support callbacks"))
+    estimation_prob = _fixed_parameter_problem(prob)
+    solve_kwargs = merge(
+        (; kwargs...),
+        (;
+            dense = true,
+            save_everystep = true,
+            save_start = true,
+            save_end = true,
+            saveat = (),
+            save_idxs = nothing,
+        )
+    )
+    sol = SciMLBase.solve(
+        estimation_prob, alg.alg, args...; abstol, reltol, solve_kwargs...
+    )
+    _validate_adjoint_solution(sol)
+    directions = _orthogonal_directions(prob.u0, alg.samples, alg.rng)
+    return _adjoint_error_estimate(
+        sol, alg, directions;
+        adjoint_abstol,
+        adjoint_reltol,
+        quadrature_abstol,
+        quadrature_reltol
+    )
+end
+
+function SciMLBase.__solve(
+        prob::SciMLBase.AbstractODEProblem, alg::GlobalAdjoint, args...;
+        abstol = something(alg.gtol, 1.0e-6),
+        reltol = something(alg.gtol, 1.0e-3),
+        kwargs...
+    )
+    alg.gtol === nothing &&
+        throw(ArgumentError("GlobalAdjoint requires a positive `gtol` constructor keyword"))
+    _validate_tolerances(abstol, reltol, "local")
+    haskey(kwargs, :callback) &&
+        throw(ArgumentError("GlobalAdjoint does not currently support callbacks"))
+
+    gtol = alg.gtol
+    options = alg.options
+    estimation_prob = _fixed_parameter_problem(prob)
+    directions = _orthogonal_directions(prob.u0, alg.samples, alg.rng)
+    local_abstol = abstol
+    local_reltol = reltol
+    trial_kwargs = merge(
+        (; kwargs...),
+        (;
+            dense = true,
+            save_everystep = true,
+            save_start = true,
+            save_end = true,
+            saveat = (),
+            save_idxs = nothing,
+        )
+    )
+    last_estimate = oftype(float(gtol), Inf)
+
+    for _ in 1:options.maxiters
+        trial_sol = SciMLBase.solve(
+            estimation_prob, alg.alg, args...;
+            abstol = local_abstol, reltol = local_reltol, trial_kwargs...
+        )
+        _validate_adjoint_solution(trial_sol)
+        last_estimate = _adjoint_error_estimate(
+            trial_sol, alg, directions;
+            adjoint_abstol = options.adjoint_abstol,
+            adjoint_reltol = options.adjoint_reltol,
+            quadrature_abstol = options.quadrature_abstol,
+            quadrature_reltol = options.quadrature_reltol
+        )
+        isfinite(last_estimate) ||
+            throw(ErrorException("the adjoint global error estimate is not finite"))
+
+        if last_estimate <= gtol
+            return SciMLBase.solve(
+                prob, alg.alg, args...;
+                abstol = local_abstol, reltol = local_reltol, kwargs...
+            )
+        end
+
+        tolerance_scale = min(0.5, options.safety * gtol / last_estimate)
+        local_abstol *= tolerance_scale
+        local_reltol *= tolerance_scale
+        iszero(local_abstol) && iszero(local_reltol) &&
+            throw(ErrorException("local tolerances underflowed during global error control"))
+    end
+
+    throw(
+        ErrorException(
+            "failed to meet gtol=$(gtol) after $(options.maxiters) iterations; " *
+                "last estimated global error was $(last_estimate)"
+        )
+    )
+end

--- a/test/adjoint_tests.jl
+++ b/test/adjoint_tests.jl
@@ -1,0 +1,59 @@
+using GlobalDiffEq, OrdinaryDiffEq, Random
+using Test
+import SciMLBase
+
+@testset "Adjoint error estimation and control" begin
+    function linear!(du, u, p, t)
+        du[1] = p * u[1]
+        return nothing
+    end
+
+    rate = 2.0
+    tspan = (0.0, 2.0)
+    linear_prob = ODEProblem(linear!, [1.0], tspan, rate)
+    estimator_alg = GlobalAdjoint(Tsit5(); samples = 1, rng = Xoshiro(123))
+
+    coarse_sol = solve(
+        linear_prob, Tsit5();
+        abstol = 1.0e-4, reltol = 1.0e-4, dense = true, save_everystep = true
+    )
+    estimated_error = adjoint_error_estimate(
+        linear_prob, estimator_alg; abstol = 1.0e-4, reltol = 1.0e-4
+    )
+    actual_error = abs(coarse_sol.u[end][1] - exp(rate * tspan[2]))
+
+    @test estimated_error > 0
+    @test estimated_error / actual_error ≈ 1 rtol = 0.15
+
+    gtol = 1.0e-6
+    controlled_sol = solve(
+        linear_prob,
+        GlobalAdjoint(Tsit5(); gtol, samples = 1, rng = Xoshiro(321));
+        abstol = 1.0e-3, reltol = 1.0e-3
+    )
+    @test abs(controlled_sol.u[end][1] - exp(rate * tspan[2])) <= gtol
+    @test controlled_sol.prob.p === rate
+
+    forcing = t -> 0.1sin(t)
+    forced(u, p, t) = [-u[1] + p(t)]
+
+    forced_prob = ODEProblem(forced, [0.0], (0.0, 1.0), forcing)
+    callable_parameter_estimate = adjoint_error_estimate(
+        forced_prob, GlobalAdjoint(Tsit5(); samples = 1, rng = Xoshiro(456));
+        abstol = 1.0e-4, reltol = 1.0e-4
+    )
+    @test isfinite(callable_parameter_estimate)
+    @test callable_parameter_estimate >= 0
+
+    adjoint_alg = GlobalAdjoint(Tsit5())
+    @test !SciMLBase.allows_arbitrary_number_types(adjoint_alg)
+    @test !SciMLBase.allowscomplex(adjoint_alg)
+    @test !SciMLBase.isautodifferentiable(adjoint_alg)
+    @test_throws ArgumentError GlobalAdjoint(Tsit5(); samples = 0)
+    @test_throws ArgumentError GlobalAdjoint(Tsit5(); gtol = -1.0)
+    @test_throws ArgumentError solve(linear_prob, adjoint_alg)
+
+    callback = DiscreteCallback((u, t, integrator) -> false, integrator -> nothing)
+    callback_prob = ODEProblem(linear!, [1.0], tspan, rate; callback)
+    @test_throws ArgumentError adjoint_error_estimate(callback_prob, adjoint_alg)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,9 @@ run_tests(;
         @safetestset "Algorithm traits forwarding" begin
             include("algorithm_traits_tests.jl")
         end
+        @safetestset "Adjoint error estimation and control" begin
+            include("adjoint_tests.jl")
+        end
         return @safetestset "BigFloat support" begin
             include("bigfloat_tests.jl")
         end


### PR DESCRIPTION
## Summary

- add `GlobalAdjoint`, an ODE algorithm wrapper that estimates endpoint error with randomized adjoint projections and refines local tolerances until the requested global tolerance is met
- add `adjoint_error_estimate` for standalone a posteriori endpoint-error estimation
- construct reverse problems with the public `SciMLSensitivity.ODEAdjointProblem` and `QuadratureAdjoint` APIs, and integrate the dense-interpolation defect with QuadGK
- treat parameters as fixed SciML structures so scalar and callable parameters work without recreating parameter-derivative bindings
- document the public API, add focused tests, and bump the minor version to 1.3.0

## Design

The estimator follows Cao and Petzold's adjoint defect-projection method. It samples orthogonal terminal directions, solves the corresponding adjoints through SciMLSensitivity, projects the numerical interpolation defect, and applies the small-sample norm factor. This replaces the abandoned symbolic-Jacobian approach from #15 with SciMLSensitivity's public derivative machinery.

The current implementation deliberately supports forward-time ODEs with real vector states, a standard mass matrix, no callbacks, and a solver that provides dense first-derivative interpolation.

## Validation

- `GROUP=Everything julia +1.10 --project=. -e 'using Pkg; Pkg.test()'`
  - Basic functionality: 1/1
  - Algorithm traits: 3/3
  - Adjoint estimation and control: 13/13
  - BigFloat support: 2/2
  - QA: 20 passed, 1 pre-existing declared broken
- `Runic --check src test docs`

Ignore this PR until reviewed by @ChrisRackauckas.

Closes #4.
