### PR TITLE
Adopt strict SciMLTesting QA and public API docs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,28 +1,24 @@
 name = "GlobalDiffEq"
 uuid = "1d72d19b-84cc-4cb7-a099-7cbdb9ccc67c"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.2.0"
+version = "2.0.0"
 
 [deps]
-DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Richardson = "708f8203-808e-40c0-ba2d-98a6953ed40d"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [compat]
-DiffEqBase = "7"
 LinearAlgebra = "1"
 OrdinaryDiffEq = "7"
 OrdinaryDiffEqSSPRK = "2"
 OrdinaryDiffEqTsit5 = "2"
 PrecompileTools = "1.1"
-Reexport = "0.2, 1.0"
 Richardson = "1.2"
 SafeTestsets = "0.0.1, 0.1"
 SciMLBase = "3"
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 Test = "1"
 julia = "1.10"
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,11 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+GlobalDiffEq = "1d72d19b-84cc-4cb7-a099-7cbdb9ccc67c"
+OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
+
+[compat]
+Documenter = "1"
+GlobalDiffEq = "2"
+OrdinaryDiffEq = "7"
+SciMLBase = "3"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,21 @@
+using Documenter, GlobalDiffEq
+
+DocMeta.setdocmeta!(
+    GlobalDiffEq,
+    :DocTestSetup,
+    :(using GlobalDiffEq, OrdinaryDiffEq, SciMLBase);
+    recursive = true,
+)
+
+makedocs(;
+    sitename = "GlobalDiffEq.jl",
+    modules = [GlobalDiffEq],
+    checkdocs = :exports,
+    doctest = true,
+    pages = [
+        "Home" => "index.md",
+        "Public API" => "api.md",
+    ],
+)
+
+deploydocs(repo = "github.com/SciML/GlobalDiffEq.jl.git", devbranch = "master")

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,9 @@
+# Public API
+
+```@meta
+CurrentModule = GlobalDiffEq
+```
+
+```@docs
+GlobalRichardson
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,5 +1,6 @@
 # GlobalDiffEq.jl
 
-```@autodocs
-Modules = [GlobalDiffEq]
-```
+`GlobalDiffEq.jl` provides global Richardson extrapolation for fixed-step ODE solves.
+
+Problem construction and `solve` are provided by
+[SciMLBase](https://docs.sciml.ai/SciMLBase/stable/).

--- a/src/GlobalDiffEq.jl
+++ b/src/GlobalDiffEq.jl
@@ -1,19 +1,44 @@
 module GlobalDiffEq
 
-using Reexport: @reexport
-@reexport using DiffEqBase
-
 import OrdinaryDiffEq, Richardson, SciMLBase
+import SciMLBase: __solve
 using PrecompileTools: @setup_workload, @compile_workload
+using SciMLBase: AbstractDAEProblem, AbstractODEAlgorithm, AbstractODEProblem, ODEProblem,
+    solve
 
-abstract type GlobalDiffEqAlgorithm <: SciMLBase.AbstractODEAlgorithm end
+abstract type GlobalDiffEqAlgorithm <: AbstractODEAlgorithm end
 
 """
     GlobalRichardson(alg)
 
-Wrap an ODE algorithm with global Richardson extrapolation.
+Wrap the fixed-step ODE algorithm `alg` with global Richardson extrapolation.
+
+`GlobalRichardson` solves the problem at successively refined fixed step sizes and uses
+Richardson extrapolation to improve the solution at the requested output times. The wrapped
+algorithm must be an `AbstractODEAlgorithm`; adaptivity is disabled for the inner solves.
+
+# Arguments
+
+- `alg`: An ODE algorithm to run at refined fixed step sizes, such as `Tsit5()` or `SSPRK33()`.
+
+# Fields
+
+- `alg`: The wrapped fixed-step ODE algorithm.
+
+# Example
+
+```jldoctest
+julia> using GlobalDiffEq, OrdinaryDiffEq, SciMLBase
+
+julia> prob = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 1.0));
+
+julia> sol = solve(prob, GlobalRichardson(Tsit5()); dt = 0.1);
+
+julia> length(sol.u) > 1
+true
+```
 """
-struct GlobalRichardson{A <: SciMLBase.AbstractODEAlgorithm} <: GlobalDiffEqAlgorithm
+struct GlobalRichardson{A <: AbstractODEAlgorithm} <: GlobalDiffEqAlgorithm
     alg::A
 end
 
@@ -26,8 +51,8 @@ SciMLBase.allowscomplex(alg::GlobalRichardson) =
 SciMLBase.isautodifferentiable(alg::GlobalRichardson) =
     SciMLBase.isautodifferentiable(alg.alg)
 
-function SciMLBase.__solve(
-        prob::Union{SciMLBase.AbstractODEProblem, SciMLBase.AbstractDAEProblem},
+function __solve(
+        prob::Union{AbstractODEProblem, AbstractDAEProblem},
         alg::GlobalRichardson, args...;
         dt, kwargs...
     )

--- a/test/algorithm_traits_tests.jl
+++ b/test/algorithm_traits_tests.jl
@@ -1,7 +1,7 @@
 using GlobalDiffEq, OrdinaryDiffEq
 using OrdinaryDiffEqSSPRK
+import SciMLBase
 using Test
-import DiffEqBase: SciMLBase
 
 @testset "Algorithm traits forwarding" begin
     alg_inner = SSPRK33()

--- a/test/basic_functionality_tests.jl
+++ b/test/basic_functionality_tests.jl
@@ -1,5 +1,6 @@
 using GlobalDiffEq, OrdinaryDiffEq, LinearAlgebra
 using OrdinaryDiffEqSSPRK
+using SciMLBase: ODEProblem, solve
 using Test
 
 @testset "Basic functionality" begin

--- a/test/bigfloat_tests.jl
+++ b/test/bigfloat_tests.jl
@@ -1,5 +1,6 @@
 using GlobalDiffEq, OrdinaryDiffEq
 using OrdinaryDiffEqSSPRK
+using SciMLBase: ODEProblem, solve
 using Test
 
 @testset "BigFloat support" begin

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -9,9 +9,9 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8"
-GlobalDiffEq = "1"
+GlobalDiffEq = "2"
 JET = "0.9, 0.10, 0.11"
 OrdinaryDiffEq = "7"
 OrdinaryDiffEqSSPRK = "2"
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 Test = "1"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -2,20 +2,7 @@ using SciMLTesting, GlobalDiffEq, Test
 using JET
 using OrdinaryDiffEq, OrdinaryDiffEqSSPRK
 
-run_qa(
-    GlobalDiffEq;
-    explicit_imports = true,
-    api_docs_kwargs = (; rendered = true),
-    ei_kwargs = (;
-        # `SciMLBase.__solve` is SciMLBase's internal solve entry point (not part of
-        # the public API); GlobalDiffEq overloads it via its owner SciMLBase.
-        all_qualified_accesses_are_public = (; ignore = (:__solve,)),
-    ),
-    # `@reexport using DiffEqBase` deliberately reexports DiffEqBase's API, so
-    # `DiffEqBase`, `ODEProblem`, and `solve` are inherently implicit. Tracked in
-    # https://github.com/SciML/GlobalDiffEq.jl/issues/53
-    ei_broken = (:no_implicit_imports,),
-)
+run_qa(GlobalDiffEq)
 
 @testset "GlobalRichardson static analysis" begin
     @test_opt GlobalRichardson(SSPRK33())


### PR DESCRIPTION
## Summary
- move GlobalDiffEq to strict SciMLTesting 2.4 defaults
- remove the DiffEqBase blanket reexport and use SciMLBase public APIs directly
- add definition-site docs plus a rendered, doctested public API page

## Verification
- `Pkg.test()` on Julia 1.10: passed (6 assertions)
- strict SciMLTesting 2.4 QA: passed (19 QA assertions and 3 JET checks)
- Documenter doctests, `checkdocs = :exports`, and HTML rendering: passed
- Runic 1.7 `--check` and `git diff --check`: passed

Ignore until reviewed by @ChrisRackauckas.